### PR TITLE
Add react hooks linter

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -1,7 +1,8 @@
 module.exports = {
     parser: 'babel-eslint',
     plugins: [
-        'react'
+        'react',
+        'react-hooks'
     ],
     env: {
         browser: true,
@@ -17,7 +18,7 @@ module.exports = {
     },
     settings: {
         react: {
-            version: '16.4'
+            version: '16.8'
         }
     },
     rules: {
@@ -36,5 +37,7 @@ module.exports = {
             component: true,
             html: true
         }],
+
+        'react-hooks/rules-of-hooks': 'error'
     }
 };

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -23,7 +23,8 @@
   },
   "devDependencies": {
     "babel-eslint": "10.0.1",
-    "eslint": "5.12.1"
+    "eslint": "5.12.1",
+    "eslint-plugin-react-hooks": "1.0.1"
   },
   "dependencies": {
     "eslint-plugin-babel": "5.3.0",


### PR DESCRIPTION
This is the official react linter for hooks best practices.

https://www.npmjs.com/package/eslint-plugin-react-hooks

Btw.. first time PRing to this repo. Do I need to bump versions or does someone do that post-merge?